### PR TITLE
flex-betweenとflex-columnのshorthand追加

### DIFF
--- a/src/shorthand.less
+++ b/src/shorthand.less
@@ -14,3 +14,6 @@
 .fb { .flex-bottom }
 
 .fh { .flex-heart; }
+
+.fbw {.flex-between; }
+.fcm {.flex-column; }

--- a/src/shorthand.less
+++ b/src/shorthand.less
@@ -16,4 +16,4 @@
 .fh { .flex-heart; }
 
 .fbw {.flex-between; }
-.fcm {.flex-column; }
+.fclm {.flex-column; }

--- a/src/shorthand.less
+++ b/src/shorthand.less
@@ -15,5 +15,5 @@
 
 .fh { .flex-heart; }
 
-.fbw { .flex-between; }
-.fclm { .flex-column; }
+.fbw {.flex-between; }
+.fclm {.flex-column; }

--- a/src/shorthand.less
+++ b/src/shorthand.less
@@ -15,5 +15,5 @@
 
 .fh { .flex-heart; }
 
-.fbw {.flex-between; }
-.fclm {.flex-column; }
+.fbw { .flex-between; }
+.fclm { .flex-column; }


### PR DESCRIPTION
`flex-column`==`fclm`
 `flex-between`==`fbw`
上記を追加しました
以前のクラス名も変わらず使えます
省略系のクラス名は皆さんの意見を参考にし最終的にphiさんにOKもらってます！
