### PR TITLE
letter-spacingのshort hand追加

### DIFF
--- a/src/font.less
+++ b/src/font.less
@@ -91,7 +91,7 @@ each(100 200 300 400 500 600 700 800 900, {
 
 // letter-spacing
 .for(@nums-1-32, {
-  .letter-spacing-@{value} {
+  .letter-spacing-@{value},.ls@{value} {
     letter-spacing: @value * 1px;
   }
 });

--- a/src/font.less
+++ b/src/font.less
@@ -91,7 +91,7 @@ each(100 200 300 400 500 600 700 800 900, {
 
 // letter-spacing
 .for(@nums-1-32, {
-  .letter-spacing-@{value},.ls@{value} {
+  .letter-spacing-@{value}, .ls@{value} {
     letter-spacing: @value * 1px;
   }
 });


### PR DESCRIPTION
tetter-spacing1-32までの小省略形追加

`letter-spacing-0`==`ls0`

少数のlsやemのlsも追加して欲しいのであれば追加します
僕はショートハンドはよく使うやつだけでいいと思ったのでこれだけ追加しました

下記のような感じで32までコンパイルされます
```
.letter-spacing-0,
.ls0 {
  letter-spacing: 0px;
}
.letter-spacing-1,
.ls1 {
  letter-spacing: 1px;
}
.letter-spacing-2,
.ls2 {
  letter-spacing: 2px;
}
```