### PR TITLE
define-color 等の色定義のメソッドでCSS変数も定義する

### DIFF
--- a/src/method.less
+++ b/src/method.less
@@ -24,6 +24,9 @@
 // 色を定義
 // 
 .define-color(@key, @value) {
+  :root {
+    --color-@{key}: @value;
+  }
   .text-@{key} {
     color: @value;
   }
@@ -36,6 +39,9 @@
 }
 
 .define-color-by-object(@key, @value) {
+  :root {
+    --color-@{key}: @value;
+  }
   .text-@{key} {
     color: @value !important;
   }
@@ -48,6 +54,9 @@
 }
 
 .define-color-grad(@key, @a, @b, @angle:0deg) {
+  :root {
+    --color-@{key}: linear-gradient(@angle, @a 0%, @b 100%);
+  }
   .@{key} {
     background-image: -webkit-linear-gradient(@a, @b);
     -webkit-background-clip: text;


### PR DESCRIPTION
lessのimportが必要なく、以下のように使えるようになります。

```
.button {
  border: 1px solid var(--color-red);
}
```
変数名は `--meltline-color-xx` にするか迷っています