### PR TITLE
ウィンドウサイズが少数点時にデバイス別判定から外れてしまうのを修正

### DIFF
--- a/src/variables.less
+++ b/src/variables.less
@@ -215,11 +215,11 @@
 }
 
 // media
-@mobile: 600px;
+@mobile: 600.999px;
 @desktop: 993px;
 @small-max: @mobile;
-@medium-min: (@mobile + 1);
-@medium-max: (@desktop - 1);
+@medium-min: (@mobile + 0.001);
+@medium-max: (@desktop - 0.001);
 @desktop-min: @desktop;
 
 @media-mobile: ~"only screen and (max-width : @{small-max})";


### PR DESCRIPTION
対応内容
- SSIA

確認方法手順
- ウィンドウズームサイズを110%以上にする
- ウィンドウサイズを以前のデバイス境界線外だった`600.5px`や`992.3px`などにする
- デバイス別のクラスが正しく適用されているか

※ローカルにて立ち上げていただき、index.htmlを直接ブラウザ上で開いて確認お願いします
