### PR TITLE
ネガティブマージン定義のメソッドを実装

### DIFF
--- a/src/box.less
+++ b/src/box.less
@@ -11,6 +11,7 @@
  * margin
  */
 .define-margin(@nums-1-100) !important;
+.define-negative-margin(@nums-1-32) !important;
 .ml-auto, .mla { margin-left: auto !important; }
 .mr-auto, .mra { margin-right: auto !important; }
 .mt-auto, .mta { margin-top: auto !important; }
@@ -27,24 +28,6 @@
     margin-right: 0 !important;
   }
 }
-
-// ネガティブマージン
-.for(@nums-1-32, {
-  // all
-  .mn@{value} { margin: @value * -1px; }
-  // top
-  .mtn@{value} { margin-top: @value * -1px; }
-  // right
-  .mrn@{value} { margin-right: @value * -1px; }
-  // bottom
-  .mbn@{value} { margin-bottom: @value * -1px; }
-  // left
-  .mln@{value} { margin-left: @value * -1px; }
-  // x
-  .mxn@{value} { margin-left: @value * -1px; margin-right: @value * -1px; }
-  // y
-  .myn@{value} { margin-top: @value * -1px; margin-bottom: @value * -1px; }
-}) !important;
 
 /*
  * border

--- a/src/method.less
+++ b/src/method.less
@@ -200,6 +200,26 @@
   });
 }
 
+// padding, margin といったプロパティ定義の大元となる関数
+.define-negative-box(@nums, @property, @prefix:~'') {
+  .for(@nums, {
+    // all
+    .@{prefix}n@{value} { @{property}: @value * -1px; }
+    // top
+    .@{prefix}tn@{value} { @{property}-top: @value * -1px; }
+    // right
+    .@{prefix}rn@{value} { @{property}-right: @value * -1px; }
+    // bottom
+    .@{prefix}bn@{value} { @{property}-bottom: @value * -1px; }
+    // left
+    .@{prefix}ln@{value} { @{property}-left: @value * -1px; }
+    // x
+    .@{prefix}xn@{value} { @{property}-left: @value * -1px; @{property}-right: @value * -1px; }
+    // y
+    .@{prefix}yn@{value} { @{property}-top: @value * -1px; @{property}-bottom: @value * -1px; }
+  });
+}
+
 // padding を定義
 .define-padding(@nums, @prefix:~'') {
   .define-box(@nums, padding, ~'@{prefix}p');
@@ -208,6 +228,11 @@
 // margin を定義
 .define-margin(@nums, @prefix:~'') {
   .define-box(@nums, margin, ~'@{prefix}m');
+}
+
+// negative-margin を定義
+.define-negative-margin(@nums, @prefix:~'') {
+  .define-negative-box(@nums, margin, ~'@{prefix}m');
 }
 
 // rounded を定義

--- a/src/method.less
+++ b/src/method.less
@@ -200,7 +200,7 @@
   });
 }
 
-// padding, margin といったプロパティ定義の大元となる関数
+// マイナス値の margin のプロパティ定義の大元となる関数
 .define-negative-box(@nums, @property, @prefix:~'') {
   .for(@nums, {
     // all

--- a/src/responsive.less
+++ b/src/responsive.less
@@ -290,14 +290,17 @@
 @media @media-mobile {
   .define-padding(@nums-1-100, s-) !important;
   .define-margin(@nums-1-100, s-) !important;
+  .define-negative-margin(@nums-1-32, s-) !important;
 }
 @media @media-tablet {
   .define-padding(@nums-1-100, m-) !important;
   .define-margin(@nums-1-100, m-) !important;
+  .define-negative-margin(@nums-1-32, m-) !important;
 }
 @media @media-desktop {
   .define-padding(@nums-1-100, l-) !important;
   .define-margin(@nums-1-100, l-) !important;
+  .define-negative-margin(@nums-1-32, l-) !important;
 }
 
 


### PR DESCRIPTION
# 対応内容
- `mtn`のようなマイナス値のmargin定義をメソッドを介して定義できるように実装
- 1-32の値は引き続きデフォルトとして定義される
- 同じく1-32の値をレスポンシブ時のデフォルト定義に追加

各プロジェクトで個別で定義していたところを以下のように一括定義できる想定です
```
.define-negative-margin(
  33
  56
);
```
```
//- sp
@prefix: s-;
.define-negative-margin(
  36
  44
,@prefix) !important;
```

# 確認方法
- ローカルで立ち上げた際に生成されるmeltline.cssの差分が適切か
